### PR TITLE
Add composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,10 @@
+{
+    "name":"orocrm/magento-orocrm-tracking",
+    "type":"magento-module",
+    "license":"OSL-3.0",
+    "homepage":"https://github.com/orocrm/magento-orocrm-tracking",
+    "description":"This extension adds the pre-configured OroCrm tracking script to your Magento Store.",
+    "require":{
+        "magento-hackathon/magento-composer-installer":"*"
+    }
+}


### PR DESCRIPTION
Adds the ability to install this package with composer. As per [this](https://github.com/Cotya/magento-composer-installer/blob/3.0/doc/Mapping.md) guide a `modman` file is enough to make it work.

Based on your other software, I chose OSL-3.0 license, please let me know if that's incorrect.
